### PR TITLE
Prevent secret key from rendering in client browser

### DIFF
--- a/includes/class-login.php
+++ b/includes/class-login.php
@@ -316,8 +316,13 @@ class Magic_Login
         wp_enqueue_style('magic-link-plugin', $this->url . 'assets/css/style.css', array());
 
         $magic_options = get_option('magic_option_name');
-        $magic_options['api_uri'] = get_rest_url();
-        wp_localize_script('magic-sdk', 'magic_wp', $magic_options);
+
+        // Specify which props are needed on the client side
+        wp_localize_script('magic-sdk', 'magic_wp', [
+            'publishable_key' => $magic_options['publishable_key'],
+            'redirect_uri' => $magic_options['redirect_uri'],
+            'api_uri' => get_rest_url(),
+        ]);
     }
 
     /**


### PR DESCRIPTION
This will prevent the secret key from showing up in the client's browser. Instead of dumping all of the properties in the `$magic_options`  array we will instead explicitly choose which props are needed on the client side. This is generally a good practice and should prevent another similar occurence if another property containing sensitive data is ever added to the `$magic_options` array.